### PR TITLE
Update Kotlin-Components

### DIFF
--- a/build-configuration/build.gradle.kts
+++ b/build-configuration/build.gradle.kts
@@ -28,21 +28,27 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,
-                browser = KmpTarget.NonJvm.JS.Browser(
-                    jsBrowserDsl = null
-                ),
-                node = KmpTarget.NonJvm.JS.Node(
-                    jsNodeDsl = null
-                ),
-                mainSourceSet = null,
-                testSourceSet = null,
+                browser = KmpTarget.NonJvm.JS.Browser(),
+                node = KmpTarget.NonJvm.JS.Node(),
             ),
 
-            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.All.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.All.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.All.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 
             KmpTarget.NonJvm.Native.Unix.Linux.Arm32Hfp.DEFAULT,
             KmpTarget.NonJvm.Native.Unix.Linux.Mips32.DEFAULT,

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,7 @@ kapt.use.worker.api=true
 kotlin.mpp.stability.nowarn=true
 
 kotlin.native.binary.memoryModel=experimental
-kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -15,6 +15,7 @@
  **/
 import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
+import io.matthewnelson.kotlin.components.kmp.publish.isSnapshotVersion
 import io.matthewnelson.kotlin.components.kmp.publish.kmpPublishRootProjectConfiguration
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -23,16 +24,16 @@ plugins {
     id("kmp-publish")
 }
 
-kmpPublishRootProjectConfiguration?.let { config ->
-    repositories {
-        if (config.versionName.endsWith("-SNAPSHOT")) {
-            maven("https://oss.sonatype.org/content/repositories/snapshots/")
-        } else {
-            maven("https://oss.sonatype.org/content/groups/staging") {
-                credentials {
-                    username = rootProject.ext.get("mavenCentralUsername").toString()
-                    password = rootProject.ext.get("mavenCentralPassword").toString()
-                }
+val pConfig = kmpPublishRootProjectConfiguration!!
+
+repositories {
+    if (pConfig.isSnapshotVersion) {
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+    } else {
+        maven("https://oss.sonatype.org/content/groups/staging") {
+            credentials {
+                username = rootProject.ext.get("mavenCentralUsername").toString()
+                password = rootProject.ext.get("mavenCentralPassword").toString()
             }
         }
     }
@@ -42,25 +43,31 @@ kmpConfiguration {
     setupMultiplatform(
         setOf(
 
-            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_11),
+            KmpTarget.Jvm.Jvm.DEFAULT,
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,
-                browser = KmpTarget.NonJvm.JS.Browser(
-                    jsBrowserDsl = null
-                ),
-                node = KmpTarget.NonJvm.JS.Node(
-                    jsNodeDsl = null
-                ),
-                mainSourceSet = null,
-                testSourceSet = null,
+                browser = KmpTarget.NonJvm.JS.Browser(),
+                node = KmpTarget.NonJvm.JS.Node(),
             ),
 
-            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.All.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
             KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.All.DEFAULT,
-            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.All.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 
             KmpTarget.NonJvm.Native.Unix.Linux.Arm32Hfp.DEFAULT,
             KmpTarget.NonJvm.Native.Unix.Linux.Mips32.DEFAULT,
@@ -71,10 +78,8 @@ kmpConfiguration {
             KmpTarget.NonJvm.Native.Mingw.X86.DEFAULT,
         ),
         commonMainSourceSet = {
-            project.kmpPublishRootProjectConfiguration?.let { config ->
-                dependencies {
-                    implementation("${config.group}:build-configuration:${config.versionName}")
-                }
+            dependencies {
+                implementation("${pConfig.group}:build-configuration:${pConfig.versionName}")
             }
         },
     )


### PR DESCRIPTION
Updates Kotlin-Components, which:
 - Refactors KmpTargets
 - Refactors source set names
 - Adds support for remaining platforms
 - Removes gradle property `kotlin.mpp.enableCompatibilityMetadataVariant=true` in favor of Kotlin `1.6.21`'s hierarchical support